### PR TITLE
Pending BN Update: mount gunmod slot obsoletion

### DIFF
--- a/Tankmod_Revived_BN/items.json
+++ b/Tankmod_Revived_BN/items.json
@@ -641,10 +641,10 @@
     "valid_mod_locations": [
       [ "accessories", 2 ],
       [ "stock", 1 ],
-      [ "grip mount", 1 ],
-      [ "rail mount", 1 ],
-      [ "sights mount", 1 ],
-      [ "underbarrel mount", 1 ]
+      [ "grip", 1 ],
+      [ "rail", 1 ],
+      [ "sights", 1 ],
+      [ "underbarrel", 1 ]
     ],
     "reload": 250,
     "blackpowder_tolerance": 24,

--- a/Tankmod_Revived_BN/modinfo.json
+++ b/Tankmod_Revived_BN/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Chaosvolt" ],
     "maintainers": [ "Chaosvolt" ],
     "description": "The intended successor of my older, obsoleted Tanks and Other Vehicles mod.",
-    "version": "BN version, update 1/7/2023",
+    "version": "BN version, update 2/5/2024",
     "category": "vehicles",
     "dependencies": [ "bn" ]
   }


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4179 is merged.