### PR TITLE
Pending BN Update: vehicle repairs cost materials

### DIFF
--- a/Tankmod_Revived_BN/parts.json
+++ b/Tankmod_Revived_BN/parts.json
@@ -58,7 +58,7 @@
         "time": "60 m",
         "using": [ [ "vehicle_bolt", 1 ], [ "welding_standard", 10 ] ]
       },
-      "repair": { "skills": [ [ "mechanics", 8 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] }
+      "repair": { "skills": [ [ "mechanics", 8 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ], [ "steel_standard", 1 ] ] }
     }
   },
   {
@@ -93,7 +93,7 @@
         "time": "60 m",
         "using": [ [ "vehicle_bolt", 1 ], [ "welding_standard", 10 ] ]
       },
-      "repair": { "skills": [ [ "mechanics", 9 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] }
+      "repair": { "skills": [ [ "mechanics", 9 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ], [ "steel_standard", 1 ] ] }
     }
   },
   {
@@ -128,7 +128,7 @@
         "time": "60 m",
         "using": [ [ "vehicle_bolt", 1 ], [ "welding_standard", 10 ] ]
       },
-      "repair": { "skills": [ [ "mechanics", 8 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] }
+      "repair": { "skills": [ [ "mechanics", 8 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ], [ "steel_standard", 1 ] ] }
     }
   },
   {
@@ -192,7 +192,7 @@
         "time": "60 m",
         "using": [ [ "vehicle_bolt", 1 ], [ "welding_standard", 10 ] ]
       },
-      "repair": { "skills": [ [ "mechanics", 8 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] }
+      "repair": { "skills": [ [ "mechanics", 8 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ], [ "steel_tiny", 2 ] ] }
     }
   }
 ]

--- a/Tankmod_Revived_BN/treads.json
+++ b/Tankmod_Revived_BN/treads.json
@@ -25,7 +25,11 @@
     "requirements": {
       "install": { "skills": [ [ "mechanics", 6 ] ], "time": "60 m", "using": [ [ "vehicle_bolt", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 4 ] ], "time": "30 m", "using": [ [ "vehicle_bolt", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 7 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] }
+      "repair": {
+        "skills": [ [ "mechanics", 7 ] ],
+        "time": "60 m",
+        "using": [ [ "welding_standard", 5 ], [ "steel_tiny", 1 ], [ "tire_repair", 1 ] ]
+      }
     },
     "flags": [ "WHEEL", "VARIABLE_SIZE", "MULTISQUARE", "TRACKED" ]
   },
@@ -54,7 +58,7 @@
     "requirements": {
       "install": { "skills": [ [ "mechanics", 7 ] ], "time": "60 m", "using": [ [ "vehicle_bolt", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 5 ] ], "time": "30 m", "using": [ [ "vehicle_bolt", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 8 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] }
+      "repair": { "skills": [ [ "mechanics", 8 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ], [ "steel_tiny", 2 ] ] }
     },
     "flags": [ "WHEEL", "VARIABLE_SIZE", "MULTISQUARE", "TRACKED" ]
   },
@@ -83,7 +87,7 @@
     "requirements": {
       "install": { "skills": [ [ "mechanics", 7 ] ], "time": "60 m", "using": [ [ "vehicle_bolt", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 5 ] ], "time": "30 m", "using": [ [ "vehicle_bolt", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 8 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] }
+      "repair": { "skills": [ [ "mechanics", 8 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ], [ "steel_standard", 1 ] ] }
     },
     "flags": [ "WHEEL", "VARIABLE_SIZE", "MULTISQUARE", "TRACKED" ]
   }


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4293 is merged. Adds material costs to repairing the makeshift tank guns and to treads.