### PR TITLE
Pending BN Update: JSONized surround start

### DIFF
--- a/Tankmod_Revived_BN/scenarios.json
+++ b/Tankmod_Revived_BN/scenarios.json
@@ -10,6 +10,7 @@
     "start_name": "Radio Tower",
     "allowed_locs": [ "sloc_tankmod_radio_tower" ],
     "missions": [ "MISSION_TANK_SUPPLY_RUN" ],
-    "flags": [ "CITY_START", "LONE_START", "SUM_START", "SUR_START" ]
+    "surround_groups": [ [ "GROUP_BLACK_ROAD", 70.0 ] ],
+    "flags": [ "CITY_START", "LONE_START", "SUM_START" ]
   }
 ]


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4665 is merged, this updates the one `SUR_START` scenario in the mod accordingly.