### PR TITLE
Pending BN Update: Shrapnel deals ballistic damage

### DIFF
--- a/Tankmod_Revived_BN/ammo_effects.json
+++ b/Tankmod_Revived_BN/ammo_effects.json
@@ -10,7 +10,7 @@
     "type": "ammo_effect",
     "explosion": {
       "damage": 400,
-      "fragment": { "impact": { "damage_type": "cut", "amount": 400, "armor_multiplier": 3 }, "range": 10 },
+      "fragment": { "impact": { "damage_type": "bullet", "amount": 400, "armor_multiplier": 3 }, "range": 10 },
       "radius": 10
     }
   },


### PR DESCRIPTION
Easy smol PR set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4738 is merged, changing 155mm frag shells to use bullet damage instead of cut for their fragmentation.